### PR TITLE
styling fixes - Signin/Signup

### DIFF
--- a/views/signin.handlebars
+++ b/views/signin.handlebars
@@ -1,11 +1,11 @@
 
-<div class="align-items-center d-flex d-lg-grid min-vh-100">
+<div class="align-items-center d-lg-grid min-vh-100 pt-5">
     <div class="row d-flex justify-content-center">
         {{!-- logo --}}
-        <div class="col-12 d-flex justify-content-center p-5">
+        {{!-- <div class="col-12 d-flex justify-content-center p-5">
 
             <img src="/assets/images/OffloadLogo.png" alt="Offload">
-        </div>
+        </div> --}}
         {{!-- form --}}
         <div class="col-12 d-flex justify-content-center">
             <form>


### PR DESCRIPTION
Commented out extra image, removed tag that wasn't functioning correctly without the image, causing input area to be in wrong position of page